### PR TITLE
Improve landing MaxMind attribution, More Info UX, and README; enable…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **IP Clem** is a simple python-based web application that displays the visitor’s **public IP address**, geolocation, ISP info, and other details. It includes a dynamic map and a privacy notice. This project is intended **for educational purposes only**.
 
+**This project was developed with the assistance of AI (artificial intelligence) tools.**
+
 ---
 
 ## Features
@@ -28,6 +30,10 @@
 - gunicorn==23.0.0
 - ipinfo==5.3.0
 - maxminddb==3.0.0
+
+### MaxMind DB format (`maxminddb`)
+
+Offline geolocation reads an **MMDB** (MaxMind DB) file—the same binary database format used by [MaxMind GeoIP databases](https://www.maxmind.com/en/geoip-databases). The **`maxminddb`** Python package is the low-level reader for that format. In this app, the [ipinfo](https://pypi.org/project/ipinfo/) client loads your **IPinfo Lite** `.mmdb` file and uses those MaxMind-compatible lookups for city, region, country, coordinates, timezone, and related fields. You provide the MMDB path in `app.py` (see [Flask App](#flask-app)); obtaining and updating the Lite database file is covered in [Getting the IPinfo Lite Database](#getting-the-ipinfo-lite-database).
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,9 @@ import ipinfo
 from datetime import datetime
 
 app = Flask(__name__)
+# Without this, Jinja keeps the first compiled copy of each template while DEBUG is off,
+# so HTML edits do not show until the process restarts.
+app.config["TEMPLATES_AUTO_RELOAD"] = True
 
 # -----------------------------
 #  SETTINGS – OFFLINE IPINFO DB
@@ -98,12 +101,10 @@ def index():
 
     # Browser info
     user_agent = request.headers.get("User-Agent", "Unknown")
-    client_port = request.environ.get("REMOTE_PORT", "Unknown")
 
     return render_template(
         "index.html",
         client_ip=client_ip,
-        client_port=client_port,
         geo=geo,
         user_agent=user_agent,
         current_year=datetime.now().year,

--- a/static/style.css
+++ b/static/style.css
@@ -21,6 +21,29 @@ h4 {
   white-space: normal;
 }
 
+.maxmind-callout {
+  background: #e8f4fc;
+  border: 1px solid #b8d4ea;
+  border-radius: 8px;
+  padding: 14px 18px;
+  margin: 18px 0 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.maxmind-callout a {
+  font-weight: 600;
+  color: #0b5cab;
+}
+
+.maxmind-callout a:hover {
+  text-decoration: underline;
+}
+
+#more-info {
+  scroll-margin-top: 12px;
+}
+
 .info-box {
   background: white;
   border-radius: 8px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,13 +12,15 @@
   <div class="container">
     <h1>Your IP Address is <strong>{{ client_ip }}</strong></h1>
     <div class="info-box">
-      <h4>More Information</h4>
-      <hr>
       <p><strong>Approximate Location:</strong> {{ geo.city }}, {{ geo.region }}, {{ geo.country }}</p>
       <p><strong>ISP:</strong> {{ geo.isp_name }}</p>
       <hr>
-      <p>Scroll down for even <strong>MORE</strong> info!</p>
+      <p><a href="#more-info">More Info</a></p>
     </div>
+    <p class="maxmind-callout">
+      Approximate IP location is analyzed using the <strong>MaxMind DB (MMDB)</strong> format.
+      <a href="https://www.maxmind.com/en/geoip-databases" target="_blank" rel="noopener">Learn more about MaxMind GeoIP databases</a>.
+    </p>
   </div>
 
   <div class="image-container">
@@ -47,11 +49,10 @@
   </div>
 
   <div class="container">
-    <h1>Even More Information</h1>
+    <h1>More Info</h1>
     <div class="info-box">
       <p><strong>IP Address:</strong> {{ client_ip }}</p>
       <p><strong>ISP:</strong> {{ geo.isp_name }}</p>
-      <p><strong>Port:</strong> {{ client_port }}</p>
       <p><strong>ASN:</strong> {{ geo.asn }}</p>
       <p><strong>Approximate Location:</strong> {{ geo.city }}, {{ geo.region }}, {{ geo.country }}</p>
       <p><strong>Timezone:</strong> {{ geo.timezone }}</p>
@@ -68,7 +69,7 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="{{ url_for('static', filename='map.js') }}"></script>
   <script src="{{ url_for('static', filename='video.js') }}"></script>
-  <footer>
+  <footer id="more-info">
     <p>
       <a href="https://github.com/cobycodes/ipclem" target="_blank" rel="noopener">GitHub - cobycodes/ipclem</a>
     </p>


### PR DESCRIPTION
Landing page: MaxMind attribution, More Info UX, README updates

Description
This PR refreshes the home page copy and structure around geolocation attribution, simplifies the “more details” flow, and documents offline MMDB usage and tooling in the README.

UI

Adds a MaxMind DB (MMDB) callout below the summary box (with styling) and links to MaxMind GeoIP databases.
Replaces the old “scroll for more” line with an in-page More Info link to the bottom of the page.
Drops the redundant “More Information” heading; renames the lower section to More Info.
Removes the Port field from the detailed block.
Docs

Expands README with how maxminddb / MMDB fits with the IPinfo Lite offline database.
Adds a clear AI-assisted development disclaimer.
Dev experience

Enables Flask TEMPLATES_AUTO_RELOAD so template edits show up during local runs without a manual restart when debug is off.